### PR TITLE
refine argument for query

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install this application:
 
 Monday.com requires users to authenticate using a JSON Web Token generated through the dashboard. Once you have your token, copy the `.env.example` file in the root folder of this application to `.env` and add your token as the value for the `MONDAY_TOKEN` key.
 
-## Client Instantiation
+### Client Instantiation
 
 You can instantiate a Monday Client by providing your Monday JWT as an argument to `Monday::Client.new`:
 
@@ -28,9 +28,14 @@ client = Monday::Client.new(token: ENV['MONDAY_TOKEN'])
 To query the Monday.com API do the following:
 
 * Build a request query either using the [Monday.com API Playground](https://israelrb.monday.com/apps/playground) or Postman.
+* You can submit a request query to the Explorer method in a Hash format, and the library will convert it for you before sending to the API.
 * Once you have a query you can execute the following:
 
 ```ruby
+query = {
+  query: "{query { me { name } } }"
+}
+
 client.query.new_query(query)
 ```
 

--- a/lib/monday/http_request.rb
+++ b/lib/monday/http_request.rb
@@ -13,11 +13,20 @@ class Monday::HttpRequest
     request = Net::HTTP::Get.new(url)
     request["Content-Type"] = "application/json"
     request["Authorization"] = "#{ENV['MONDAY_TOKEN']}"
-    request.body = query
+    request.body = manage_query(query)
     response = https.request(request)
     
 
     parse(response)
+  end
+
+  def manage_query(query)
+    if query.is_a?(Hash)
+      query = query.collect{|k,v| [k.to_s, v]}.to_h.to_s.gsub('=>', ':')
+      query
+    end
+
+    query
   end
 
   def parse(response)

--- a/lib/monday/query.rb
+++ b/lib/monday/query.rb
@@ -5,41 +5,21 @@ class Monday::Query < Monday::HttpRequest
 
   # Make a new query request
   #
-  # @return JSON
+  # Your query can be provided in a Hash with the key being 'query'.
+  # The key in the Hash argument can either be a Symbol or a String.
+  #
+  # The value of the 'query' key must be a String that starts with the
+  # word query and an open curly brace:
+  # "query {"
   # 
+  # The end of your query ends with a closing curly brace still enclosed
+  # in the string:
+  # "}"
+  #
+  # @return JSON
+  #
   # @example
-  #   results = Monday::Query.new_query("{
-  #   \"query\":
-  #     \"\\nquery {
-  #       \\n  me {
-  #         \\n    name\\n  
-  #         }\\n  boards(limit:1) {
-  #           \\n    name\\n    \\n    
-  #           columns {\\n      
-  #             title\\n      
-  #             id\\n      
-  #             type\\n    
-  #           }\\n    \\n    
-  #           groups {\\n    \\
-  #             ttitle\\n      
-  #             id\\n    
-  #           }\\n    \\n    
-  #           items {\\n      
-  #             name\\n      
-  #             group {\\n        
-  #               id\\n      
-  #             }\\n      \\n      
-  #           column_values {\\n        
-  #             id\\n        
-  #             value\\n        
-  #             text\\n      
-  #           }\\n    
-  #         }\\n  
-  #       }\\n
-  #     }\",
-  #     \"variables\":{}
-  #   }")
-
+  #   results = Monday::Query.new_query({query: "query { me { name } }"})
   def new_query(query)
     response = request(query)
 


### PR DESCRIPTION
Allow user to provide GraphQL query in the form of a Hash and the library will adjust it for the API