### PR TITLE
rename method

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ query = {
   query: "{query { me { name } } }"
 }
 
-client.query.new_query(query)
+client.query.search(query)
 ```
 
 ## Contributing

--- a/lib/monday/query.rb
+++ b/lib/monday/query.rb
@@ -19,8 +19,8 @@ class Monday::Query < Monday::HttpRequest
   # @return JSON
   #
   # @example
-  #   results = Monday::Query.new_query({query: "query { me { name } }"})
-  def new_query(query)
+  #   results = Monday::Query.search({query: "query { me { name } }"})
+  def search(query)
     response = request(query)
 
     response


### PR DESCRIPTION
Rename method from `new_query` to `search`